### PR TITLE
Pre-launch day bug fixes 

### DIFF
--- a/src/components/Analysis/MoveMap.tsx
+++ b/src/components/Analysis/MoveMap.tsx
@@ -196,8 +196,8 @@ export const MoveMap: React.FC<Props> = ({
               tickLine={false}
               tickMargin={0}
               tick={{ fill: 'white', fontSize: getTickFontSize() }}
-              domain={[-4, 0]}
-              ticks={[-4, -3, -2, -1, 0]}
+              domain={[-3, 0]}
+              ticks={[-3, -2, -1, 0]}
             >
               <Label
                 value="← Blunders"

--- a/src/components/Board/MovesContainer.tsx
+++ b/src/components/Board/MovesContainer.tsx
@@ -115,6 +115,19 @@ export const MovesContainer: React.FC<Props> = (props) => {
   } = props
   const { isMobile } = useContext(WindowSizeContext)
 
+  // Helper function to determine if move indicators should be shown
+  const shouldShowIndicators = (node: GameNode | null) => {
+    if (!node || !showAnnotations) return false
+
+    // Calculate ply from start: (moveNumber - 1) * 2 + (turn === 'b' ? 1 : 0)
+    const moveNumber = node.moveNumber
+    const turn = node.turn
+    const plyFromStart = (moveNumber - 1) * 2 + (turn === 'b' ? 1 : 0)
+
+    // Only show indicators after the first 6 ply (moves 1, 2, and 3)
+    return plyFromStart >= 6
+  }
+
   const baseController = useBaseTreeController(type)
 
   const mainLineNodes = useMemo(() => {
@@ -239,10 +252,10 @@ export const MovesContainer: React.FC<Props> = (props) => {
                   } ${highlightSet.has(pairIndex * 2 + 1) ? 'bg-human-3/80' : ''}`}
                 >
                   <span>{pair.whiteMove.san ?? pair.whiteMove.move}</span>
-                  {showAnnotations && pair.whiteMove.blunder && <BlunderIcon />}
-                  {showAnnotations && pair.whiteMove.unlikelyGoodMove && (
-                    <UnlikelyGoodMoveIcon />
-                  )}
+                  {shouldShowIndicators(pair.whiteMove) &&
+                    pair.whiteMove.blunder && <BlunderIcon />}
+                  {shouldShowIndicators(pair.whiteMove) &&
+                    pair.whiteMove.unlikelyGoodMove && <UnlikelyGoodMoveIcon />}
                 </div>
               )}
               {pair.blackMove && (
@@ -257,10 +270,10 @@ export const MovesContainer: React.FC<Props> = (props) => {
                   } ${highlightSet.has(pairIndex * 2 + 2) ? 'bg-human-3/80' : ''}`}
                 >
                   <span>{pair.blackMove.san ?? pair.blackMove.move}</span>
-                  {showAnnotations && pair.blackMove.blunder && <BlunderIcon />}
-                  {showAnnotations && pair.blackMove.unlikelyGoodMove && (
-                    <UnlikelyGoodMoveIcon />
-                  )}
+                  {shouldShowIndicators(pair.blackMove) &&
+                    pair.blackMove.blunder && <BlunderIcon />}
+                  {shouldShowIndicators(pair.blackMove) &&
+                    pair.blackMove.unlikelyGoodMove && <UnlikelyGoodMoveIcon />}
                 </div>
               )}
             </React.Fragment>
@@ -300,10 +313,11 @@ export const MovesContainer: React.FC<Props> = (props) => {
               className={`col-span-2 flex h-7 flex-1 cursor-pointer flex-row items-center justify-between px-2 text-sm hover:bg-background-2 ${baseController.currentNode === whiteNode && 'bg-human-4/20'} ${highlightSet.has(index * 2 + 1) && 'bg-human-3/80'}`}
             >
               {whiteNode?.san ?? whiteNode?.move}
-              {showAnnotations && whiteNode?.blunder && <BlunderIcon />}
-              {showAnnotations && whiteNode?.unlikelyGoodMove && (
-                <UnlikelyGoodMoveIcon />
+              {shouldShowIndicators(whiteNode) && whiteNode?.blunder && (
+                <BlunderIcon />
               )}
+              {shouldShowIndicators(whiteNode) &&
+                whiteNode?.unlikelyGoodMove && <UnlikelyGoodMoveIcon />}
             </div>
             {showAnnotations && whiteNode?.getVariations().length ? (
               <FirstVariation
@@ -321,10 +335,11 @@ export const MovesContainer: React.FC<Props> = (props) => {
               className={`col-span-2 flex h-7 flex-1 cursor-pointer flex-row items-center justify-between px-2 text-sm hover:bg-background-2 ${baseController.currentNode === blackNode && 'bg-human-4/20'} ${highlightSet.has(index * 2 + 2) && 'bg-human-3/80'}`}
             >
               {blackNode?.san ?? blackNode?.move}
-              {showAnnotations && blackNode?.blunder && <BlunderIcon />}
-              {showAnnotations && blackNode?.unlikelyGoodMove && (
-                <UnlikelyGoodMoveIcon />
+              {shouldShowIndicators(blackNode) && blackNode?.blunder && (
+                <BlunderIcon />
               )}
+              {shouldShowIndicators(blackNode) &&
+                blackNode?.unlikelyGoodMove && <UnlikelyGoodMoveIcon />}
             </div>
             {showAnnotations && blackNode?.getVariations().length ? (
               <FirstVariation
@@ -399,6 +414,14 @@ function VariationTree({
   level: number
 }) {
   const variations = node.getVariations()
+
+  // Helper function to determine if move indicators should be shown in variations
+  const shouldShowVariationIndicators = (node: GameNode) => {
+    const moveNumber = node.moveNumber
+    const turn = node.turn
+    const plyFromStart = (moveNumber - 1) * 2 + (turn === 'b' ? 1 : 0)
+    return plyFromStart >= 6
+  }
   return (
     <li className={`tree-li ${level === 0 ? 'no-tree-connector' : ''}`}>
       <span
@@ -412,7 +435,7 @@ function VariationTree({
         {node.moveNumber}. {node.turn === 'w' ? '...' : ''}
         {node.san}
         <span className="inline-flex items-center">
-          {node.blunder && (
+          {shouldShowVariationIndicators(node) && node.blunder && (
             <span
               className="ml-0.5 text-[8px] text-[#d73027]"
               data-tooltip-id="variation-blunder-tooltip"
@@ -420,7 +443,7 @@ function VariationTree({
               !
             </span>
           )}
-          {node.unlikelyGoodMove && (
+          {shouldShowVariationIndicators(node) && node.unlikelyGoodMove && (
             <span
               className="ml-0.5 text-[8px] text-[#2ca25f]"
               data-tooltip-id="variation-unlikely-tooltip"
@@ -484,6 +507,14 @@ function InlineChain({
   const chain: GameNode[] = []
   let current = node
 
+  // Helper function to determine if move indicators should be shown in inline chains
+  const shouldShowInlineIndicators = (node: GameNode) => {
+    const moveNumber = node.moveNumber
+    const turn = node.turn
+    const plyFromStart = (moveNumber - 1) * 2 + (turn === 'b' ? 1 : 0)
+    return plyFromStart >= 6
+  }
+
   while (current.getVariations().length === 1) {
     const child = current.getVariations()[0]
     chain.push(child)
@@ -506,7 +537,7 @@ function InlineChain({
               {child.moveNumber}. {child.turn === 'w' ? '...' : ''}
               {child.san}
               <span className="inline-flex items-center">
-                {child.blunder && (
+                {shouldShowInlineIndicators(child) && child.blunder && (
                   <span
                     className="ml-0.5 text-[8px] text-[#d73027]"
                     data-tooltip-id="inline-blunder-tooltip"
@@ -514,14 +545,15 @@ function InlineChain({
                     !
                   </span>
                 )}
-                {child.unlikelyGoodMove && (
-                  <span
-                    className="ml-0.5 text-[8px] text-[#2ca25f]"
-                    data-tooltip-id="inline-unlikely-tooltip"
-                  >
-                    !?
-                  </span>
-                )}
+                {shouldShowInlineIndicators(child) &&
+                  child.unlikelyGoodMove && (
+                    <span
+                      className="ml-0.5 text-[8px] text-[#2ca25f]"
+                      data-tooltip-id="inline-unlikely-tooltip"
+                    >
+                      !?
+                    </span>
+                  )}
               </span>
             </span>
           </Fragment>

--- a/src/components/Core/Header.tsx
+++ b/src/components/Core/Header.tsx
@@ -134,7 +134,7 @@ export const Header: React.FC = () => {
             href="/train"
             className={`${router.pathname.startsWith('/train') && 'bg-background-1'} uppercase hover:bg-background-1`}
           >
-            Train
+            Puzzles
           </Link>
           <Link
             href="/openings"

--- a/src/components/Home/HomeHero.tsx
+++ b/src/components/Home/HomeHero.tsx
@@ -214,9 +214,9 @@ export const HomeHero: React.FC<Props> = ({ scrollHandler }: Props) => {
             />
             <FeatureCard
               icon={<TrainIcon />}
-              title="Train"
+              title="Puzzles"
               description="Improve your skills with Maia's training puzzles"
-              href="/train"
+              href="/puzzles"
               index={2}
             />
             <FeatureCard

--- a/src/components/Home/PageNavigation.tsx
+++ b/src/components/Home/PageNavigation.tsx
@@ -10,7 +10,7 @@ export const PageNavigation = () => {
     >
       <NavLink href="#play-section" label="Play" />
       <NavLink href="#analysis-section" label="Analysis" />
-      <NavLink href="#train-section" label="Train" />
+      <NavLink href="#train-section" label="Puzzles" />
       <NavLink href="#more-features" label="Features" />
       <NavLink href="#main_info" label="Project" />
       <NavLink href="#team_info" label="Team" />

--- a/src/components/Home/Sections/TrainSection.tsx
+++ b/src/components/Home/Sections/TrainSection.tsx
@@ -364,10 +364,10 @@ export const TrainSection = ({ id }: TrainSectionProps) => {
           <div className="flex flex-wrap gap-4">
             <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.98 }}>
               <Link
-                href="/train"
+                href="/puzzles"
                 className="flex items-center justify-center rounded-md bg-human-3 px-6 py-3 font-medium text-white transition duration-200 hover:bg-opacity-90"
               >
-                Start Training
+                Start Puzzles
               </Link>
             </motion.div>
           </div>

--- a/src/config/tours.ts
+++ b/src/config/tours.ts
@@ -62,9 +62,9 @@ export const analysisTourSteps: TourStep[] = [
 export const trainTourSteps: TourStep[] = [
   {
     id: 'train-overview',
-    title: 'Welcome to Training',
+    title: 'Welcome to Puzzles',
     description:
-      'This is the training page where you solve chess puzzles to improve your tactical skills. Each puzzle presents a position where you need to find the best move. The puzzles are rated, and your performance affects your puzzle rating. Try to solve each puzzle by making the correct moves on the board.',
+      'This is the puzzle page where you solve chess puzzles to improve your tactical skills. Each puzzle presents a position where you need to find the best move. The puzzles are rated, and your performance affects your puzzle rating. Try to solve each puzzle by making the correct moves on the board.',
     targetId: 'train-page',
     placement: 'right',
   },

--- a/src/hooks/useAnalysisController/useMoveRecommendations.ts
+++ b/src/hooks/useAnalysisController/useMoveRecommendations.ts
@@ -124,22 +124,22 @@ export const useMoveRecommendations = (
       // Get Stockfish evaluation (default to worst possible if not evaluated)
       const cp =
         moveEvaluation.stockfish.cp_relative_vec[move] !== undefined
-          ? Math.max(-4, moveEvaluation.stockfish.cp_relative_vec[move] / 100)
-          : -4 // Worst possible Stockfish evaluation
+          ? Math.max(-3, moveEvaluation.stockfish.cp_relative_vec[move] / 100)
+          : -3 // Cap at -3 to avoid extreme values
 
       // Get Maia probability (default to 0 if not in policy)
       const prob = (moveEvaluation.maia.policy[move] || 0) * 100
 
       // Calculate opacity based on position quality
       // Moves in bottom-left (worse SF, less likely Maia) should be more transparent
-      // Normalize values: cp ranges from -4 to 0, prob ranges from 0 to ~100
-      const normalizedCp = (cp + 4) / 4 // 0 to 1 (0 = worst, 1 = best)
+      // Normalize values: cp ranges from -3 to 0, prob ranges from 0 to ~100
+      const normalizedCp = (cp + 3) / 3 // 0 to 1 (0 = worst, 1 = best)
       const normalizedProb = Math.min(prob / 50, 1) // 0 to 1 (capped at 50% for normalization)
 
-      // Combine both factors for opacity (minimum 0.2 for visibility, maximum 1.0)
+      // Combine both factors for opacity (minimum 0.2 for visibility, maximum 0.75)
       const opacity = Math.max(
-        0.2,
-        Math.min(1.0, (normalizedCp + normalizedProb) / 2),
+        0.6,
+        Math.min(0.9, (normalizedCp + normalizedProb) / 2),
       )
 
       // Calculate importance score for sorting (higher = more important)

--- a/src/hooks/useStockfishEngine/engine.ts
+++ b/src/hooks/useStockfishEngine/engine.ts
@@ -11,6 +11,7 @@ class Engine {
   private stockfish: StockfishWeb | null = null
   private isReady = false
   private nnueLoaded = false
+  private currentPositionId = ''
 
   private store: {
     [key: string]: StockfishEvaluation
@@ -65,6 +66,8 @@ class Engine {
         global.gc()
       }
 
+      // Stop any previous evaluation
+      this.stopEvaluation()
       this.store = {}
       this.legalMoveCount = legalMoveCount
       const board = new Chess(fen)
@@ -72,15 +75,12 @@ class Engine {
         .moves({ verbose: true })
         .map((x) => x.from + x.to + (x.promotion || ''))
       this.fen = fen
+      this.currentPositionId = fen + '_' + Date.now()
       this.isEvaluating = true
       this.evaluationGenerator = this.createEvaluationGenerator()
 
-      this.sendMessage('stop')
-      await this.waitForReady()
       this.sendMessage('ucinewgame')
-      await this.waitForReady()
       this.sendMessage(`position fen ${fen}`)
-      await this.waitForReady()
       this.sendMessage('go depth 18')
 
       while (this.isEvaluating) {
@@ -112,7 +112,7 @@ class Engine {
 
   private sendMessage(message: string) {
     if (this.stockfish) {
-      console.warn(message)
+      console.log(message)
       this.stockfish.uci(message)
     }
   }
@@ -121,28 +121,40 @@ class Engine {
     if (!this.stockfish) return
 
     return new Promise((resolve) => {
-      const originalListen = this.stockfish?.listen
-      if (!this.stockfish || !originalListen) {
+      if (!this.stockfish) {
         resolve()
         return
       }
 
-      this.stockfish.listen = (msg: string) => {
-        if (msg.includes('readyok')) {
+      let resolved = false
+      const originalListen = this.stockfish.listen
+
+      const tempListener = (msg: string) => {
+        if (msg.includes('readyok') && !resolved) {
+          resolved = true
           if (this.stockfish) {
             this.stockfish.listen = originalListen
           }
           resolve()
         } else {
+          // Forward all other messages to the original listener
           originalListen(msg)
         }
       }
 
+      this.stockfish.listen = tempListener
       this.stockfish.uci('isready')
     })
   }
 
   private onMessage(msg: string) {
+    console.log(msg)
+
+    // Only process evaluation messages if we're currently evaluating
+    if (!this.isEvaluating) {
+      return
+    }
+
     const matches = [
       ...msg.matchAll(
         /info depth (\d+) seldepth (\d+) multipv (\d+) score (?:cp (-?\d+)|mate (-?\d+)).+ pv ((?:\S+\s*)+)/g,
@@ -289,8 +301,10 @@ class Engine {
     this.isEvaluating = false
   }
   stopEvaluation() {
-    this.isEvaluating = false
-    this.sendMessage('stop')
+    if (this.isEvaluating) {
+      this.isEvaluating = false
+      this.sendMessage('stop')
+    }
   }
 }
 

--- a/src/pages/analysis/[...id].tsx
+++ b/src/pages/analysis/[...id].tsx
@@ -717,6 +717,7 @@ const Analysis: React.FC<Props> = ({
                     }
                     colorSanMapping={controller.colorSanMapping}
                     boardDescription={controller.boardDescription}
+                    currentNode={controller.currentNode}
                   />
                 </div>
                 <div className="flex h-full w-full bg-background-1">
@@ -765,6 +766,7 @@ const Analysis: React.FC<Props> = ({
                   }
                   colorSanMapping={controller.colorSanMapping}
                   boardDescription={controller.boardDescription}
+                  currentNode={controller.currentNode}
                 />
               </div>
               <div className="flex h-full w-auto min-w-[40%] max-w-[40%] bg-background-1 p-3">
@@ -943,6 +945,7 @@ const Analysis: React.FC<Props> = ({
                 }
                 colorSanMapping={controller.colorSanMapping}
                 boardDescription={controller.boardDescription}
+                currentNode={controller.currentNode}
               />
               <MovesByRating
                 moves={controller.movesByRating}

--- a/src/pages/puzzles.tsx
+++ b/src/pages/puzzles.tsx
@@ -103,22 +103,6 @@ const TrainPage: NextPage = () => {
     setPreviousGameResults(previousGameResults.concat([{ ...game }]))
   }, [trainingGames, previousGameResults, router])
 
-  // useEffect(() => {
-  //   if (currentIndex == trainingGames.length - 1) {
-  //     // For the current puzzle, only set to 'default' if it hasn't been completed yet
-  //     const currentPuzzleResult = previousGameResults[currentIndex]
-  //     if (currentPuzzleResult?.result !== undefined) {
-  //       // Puzzle was completed - preserve the correct status
-  //       setStatus(currentPuzzleResult.result ? 'correct' : 'forfeit')
-  //     } else {
-  //       // Puzzle not completed yet - set to default
-  //       setStatus('default')
-  //     }
-  //   } else {
-  //     setStatus('archived')
-  //   }
-  // }, [currentIndex, previousGameResults])
-
   const logGuess = useCallback(
     async (
       gameId: string,
@@ -615,7 +599,7 @@ const Train: React.FC<Props> = ({
       <div className="flex h-full w-full flex-col items-center py-4 md:py-10">
         <div className="flex h-full w-[90%] flex-row gap-4">
           <div className="flex h-[85vh] w-72 min-w-60 max-w-72 flex-col gap-2 overflow-hidden 2xl:min-w-72">
-            <GameInfo title="Training" icon="target" type="train">
+            <GameInfo title="Puzzles" icon="target" type="train">
               <p className="text-secondary">
                 Puzzle{' '}
                 <span className="text-secondary/60">#{trainingGame.id}</span>


### PR DESCRIPTION
1. Migrate to using Stockfish Win Rate instead of Maia2 Value Head for first 10 ply
2. Hide move indicators (blunder, inaccuracy, etc) on first 6 ply
3. Cap moveMap at -3 eval loss + make moves more opaque
4. Rename train to puzzles on client-facing areas
5. Add delay before inferencing Maia and Stockfish so players can zip through moves
6. Fix broken Stockfish errors