### PR TITLE
Fix opening drill target move number configuration

### DIFF
--- a/src/components/Openings/OpeningSelectionModal.tsx
+++ b/src/components/Openings/OpeningSelectionModal.tsx
@@ -464,7 +464,8 @@ const PreviewPanel: React.FC<{
     return selections.some(
       (selection) =>
         selection.opening.id === opening.id &&
-        selection.variation?.id === variation?.id,
+        selection.variation?.id === variation?.id &&
+        selection.playerColor === selectedColor,
     )
   }
 
@@ -814,6 +815,19 @@ export const OpeningSelectionModal: React.FC<Props> = ({
     }
   }, [hasTrackedModalOpen, initialSelections.length])
 
+  // Update all existing selections when global settings change
+  useEffect(() => {
+    setSelections((prevSelections) =>
+      prevSelections.map((selection) => ({
+        ...selection,
+        maiaVersion: selectedMaiaVersion.id,
+        targetMoveNumber,
+        // Update the ID to reflect the new settings
+        id: `${selection.opening.id}-${selection.variation?.id || 'main'}-${selection.playerColor}-${selectedMaiaVersion.id}-${targetMoveNumber}`,
+      })),
+    )
+  }, [selectedMaiaVersion.id, targetMoveNumber])
+
   const handleStartTour = () => {
     startTour(tourConfigs.openingDrill.id, tourConfigs.openingDrill.steps, true)
   }
@@ -849,8 +863,7 @@ export const OpeningSelectionModal: React.FC<Props> = ({
       (s) =>
         s.opening.id === opening.id &&
         s.variation?.id === variation?.id &&
-        s.playerColor === selectedColor &&
-        s.maiaVersion === selectedMaiaVersion.id,
+        s.playerColor === selectedColor,
     )
   }
 


### PR DESCRIPTION
## Summary
- Fixed opening drill configuration to properly apply global settings (target move number and Maia version) to all drills
- Added `useEffect` to update all existing selections when global settings change
- Fixed `isDuplicateSelection` functions to only check opening-specific parameters, not global settings

## Problem
The configured number of moves in the opening drill page always defaulted to 10, even if the user configured a different number of moves in the settings panel. The issue was that target move number and Maia version are **global settings** that should apply to ALL drills, but existing selections weren't being updated when these global settings changed.

## Root Cause
The target move number and Maia version are global settings configured in the right column that should apply to all selected openings. However:

1. When users created selections, they were stored with the current global settings
2. When users later changed the global settings, existing selections retained their old values
3. The `isDuplicateSelection` function incorrectly included these global settings in the comparison

## Solution
- **Added `useEffect`** to automatically update all existing selections when `targetMoveNumber` or `selectedMaiaVersion` changes
- **Fixed `isDuplicateSelection`** functions to only check opening-specific parameters (opening, variation, playerColor), not global settings
- **Global settings** now properly apply to all drills as intended in the UI design

## Test plan
- [ ] Open the opening drill selection modal
- [ ] Add an opening with default settings (10 moves)
- [ ] Change the target move number in the right panel to 15 moves
- [ ] Verify that the existing selection now shows "15 moves" instead of "10 moves"
- [ ] Add the same opening again - it should be detected as duplicate (since global settings now apply to all)
- [ ] Start drilling and verify the correct target move number (15) is used for all drills

🤖 Generated with [Claude Code](https://claude.ai/code)