### PR TITLE
fix: resolve openings tour modal conflicts and persistence

### DIFF
--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -226,7 +226,7 @@ export const Header: React.FC = () => {
         <span className="material-symbols-outlined text-3xl">menu</span>
       </button>
       {showMenu && (
-        <div className="fixed left-0 top-0 z-[10101] flex h-screen w-screen flex-col items-start justify-between bg-backdrop py-4">
+        <div className="fixed left-0 top-0 z-[1010] flex h-screen w-screen flex-col items-start justify-between bg-backdrop py-4">
           <div className="flex w-full flex-row justify-between px-4">
             <Link href="/" passHref>
               <div className="flex flex-row items-center gap-2">

--- a/src/components/Common/ModalContainer.tsx
+++ b/src/components/Common/ModalContainer.tsx
@@ -29,7 +29,7 @@ export const ModalContainer: React.FC<Props> = ({
       exit={{ opacity: 0 }}
       transition={{ duration: 0.1 }}
       onClick={dismiss}
-      className={`fixed bottom-0 top-0 z-[10102] flex w-screen items-center justify-center bg-backdrop/90 text-primary ${className}`}
+      className={`fixed bottom-0 top-0 z-[1000] flex w-screen items-center justify-center bg-backdrop/90 text-primary ${className}`}
     >
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <motion.div

--- a/src/contexts/TourContext/TourContext.tsx
+++ b/src/contexts/TourContext/TourContext.tsx
@@ -631,7 +631,7 @@ export const TourProvider: React.FC<TourProviderProps> = ({ children }) => {
               backgroundColor: 'rgb(38, 36, 45)', // background-1 to match tooltip
               overlayColor: 'rgba(0, 0, 0, 0.5)',
               spotlightShadow: '0 0 15px rgba(159, 79, 68, 0.3)',
-              zIndex: 10000,
+              zIndex: 1001,
             },
             spotlight: {
               borderRadius: '4px',

--- a/src/pages/openings/index.tsx
+++ b/src/pages/openings/index.tsx
@@ -21,6 +21,7 @@ import {
   AuthContext,
   MaiaEngineContext,
 } from 'src/contexts'
+import { useTour } from 'src/contexts/TourContext'
 import { DrillConfiguration, AnalyzedGame } from 'src/types'
 import { GameNode } from 'src/types/base/tree'
 import { MIN_STOCKFISH_DEPTH } from 'src/constants/analysis'
@@ -59,6 +60,7 @@ import {
 const OpeningsPage: NextPage = () => {
   const router = useRouter()
   const { user } = useContext(AuthContext)
+  const { endTour } = useTour()
   const [showSelectionModal, setShowSelectionModal] = useState(true)
   const [isReopenedModal, setIsReopenedModal] = useState(false)
 
@@ -66,6 +68,8 @@ const OpeningsPage: NextPage = () => {
     if (isReopenedModal) {
       setShowSelectionModal(false)
     } else {
+      // End any active tour before redirecting to prevent tour persistence on home page
+      endTour()
       router.push('/')
     }
   }


### PR DESCRIPTION
## Summary
Fixes tour visibility and persistence issues on the openings page where the tour was hidden behind the opening selection modal and persisted when redirecting to the home page.

## Issues Fixed
- **Tour hidden behind modal**: The opening selection modal had a higher z-index than the tour overlay, making the tour invisible
- **Tour persistence on redirect**: When closing the modal and redirecting to home page, the tour remained active causing overlay artifacts

## Changes Made
- Updated tour z-index from 10000 to 1001 to appear above modals
- Added `endTour()` call before redirecting to home page to properly clean up tour state
- Adjusted related modal z-indices for proper layering hierarchy

## Test Plan
- [x] Opening the openings page shows the tour correctly above the modal
- [x] Closing the modal and redirecting to home properly terminates the tour
- [x] No tour artifacts remain on home page after navigation
- [x] Build and lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)