### PR TITLE
preserve cached maia model when download URL changes

### DIFF
--- a/src/contexts/MaiaEngineContext.tsx
+++ b/src/contexts/MaiaEngineContext.tsx
@@ -34,6 +34,7 @@ export const MaiaEngineContextProvider: React.FC<{ children: ReactNode }> = ({
       model:
         process.env.NEXT_PUBLIC_MAIA_MODEL_URL ??
         'https://raw.githubusercontent.com/CSSLab/maia-platform-frontend/e23a50e/public/maia2/maia_rapid.onnx',
+      modelVersion: process.env.NEXT_PUBLIC_MAIA_MODEL_VERSION ?? '1',
       setStatus: setStatus,
       setProgress: setProgress,
       setError: setError,

--- a/src/lib/engine/maia.ts
+++ b/src/lib/engine/maia.ts
@@ -6,6 +6,7 @@ import { MaiaModelStorage } from './storage'
 
 interface MaiaOptions {
   model: string
+  modelVersion: string
   setStatus: (status: MaiaStatus) => void
   setProgress: (progress: number) => void
   setError: (error: string) => void
@@ -14,11 +15,13 @@ interface MaiaOptions {
 class Maia {
   private model!: InferenceSession
   private modelUrl: string
+  private modelVersion: string
   private options: MaiaOptions
   private storage: MaiaModelStorage
 
   constructor(options: MaiaOptions) {
     this.modelUrl = options.model
+    this.modelVersion = options.modelVersion
     this.options = options
     this.storage = new MaiaModelStorage()
 
@@ -30,7 +33,7 @@ class Maia {
     await this.storage.requestPersistentStorage()
 
     console.log('Attempting to get model from IndexedDB...')
-    const buffer = await this.storage.getModel(this.modelUrl)
+    const buffer = await this.storage.getModel(this.modelUrl, this.modelVersion)
 
     if (buffer) {
       console.log('Model found in IndexedDB, initializing...')
@@ -94,7 +97,7 @@ class Maia {
       position += chunk.length
     }
 
-    await this.storage.storeModel(this.modelUrl, buffer.buffer)
+    await this.storage.storeModel(this.modelUrl, this.modelVersion, buffer.buffer)
 
     await this.initializeModel(buffer.buffer)
     this.options.setStatus('ready')


### PR DESCRIPTION
- when the model source URL changes (e.g. switching from /public to GitHub raw), existing users with a cached model were forced to re-download ~93MB because the old code compared URLs and deleted mismatches
- adds a `modelVersion` field so cache invalidation is version-based, and URL-only changes just update the stored metadata in-place without re-downloading
- if the metadata update fails, the cached model is still returned so users are never forced to re-download