### PR TITLE
Background Maia + Stockfish analysis during drill play

### DIFF
--- a/src/hooks/useAnalysisController/useAnalysisController.ts
+++ b/src/hooks/useAnalysisController/useAnalysisController.ts
@@ -26,6 +26,7 @@ export const useAnalysisController = (
   game: AnalyzedGame,
   initialOrientation?: 'white' | 'black',
   enableAutoSave = true,
+  enableEngineAnalysis = true,
 ) => {
   const defaultOrientation = initialOrientation
     ? initialOrientation
@@ -86,6 +87,7 @@ export const useAnalysisController = (
     deepAnalysisController.progress.isAnalyzing
       ? deepAnalysisController.config.targetDepth
       : 18,
+    enableEngineAnalysis,
   )
 
   const availableMoves = useMemo(() => {

--- a/src/hooks/useAnalysisController/useEngineAnalysis.ts
+++ b/src/hooks/useAnalysisController/useEngineAnalysis.ts
@@ -15,6 +15,7 @@ export const useEngineAnalysis = (
   currentMaiaModel: string,
   setAnalysisState: React.Dispatch<React.SetStateAction<number>>,
   targetDepth = 18,
+  enabled = true,
 ) => {
   const maia = useContext(MaiaEngineContext)
   const stockfish = useContext(StockfishEngineContext)
@@ -78,7 +79,7 @@ export const useEngineAnalysis = (
   }
 
   useEffect(() => {
-    if (!currentNode) return
+    if (!currentNode || !enabled) return
 
     const board = new Chess(currentNode.fen)
     const nodeFen = currentNode.fen
@@ -163,10 +164,11 @@ export const useEngineAnalysis = (
     inProgressAnalyses,
     maia,
     setAnalysisState,
+    enabled,
   ])
 
   useEffect(() => {
-    if (!currentNode) return
+    if (!currentNode || !enabled) return
 
     const shouldForceStockfishRerun =
       stockfishDebugRerunToken > lastConsumedStockfishRerunTokenRef.current
@@ -281,5 +283,6 @@ export const useEngineAnalysis = (
     stockfishDebugRerunToken,
     currentNode?.analysis.maia?.[currentMaiaModel]?.policy,
     currentNode?.mainChild?.move,
+    enabled,
   ])
 }

--- a/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
+++ b/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
@@ -914,28 +914,60 @@ export const useOpeningDrillController = (
   const backgroundRunningRef = useRef(false)
   const backgroundCancelledRef = useRef(false)
 
-  // The long-lived loop that drains the queue
+  // Refs to the latest versions of the analysis functions so the long-lived
+  // loop always calls the current closure without needing to restart.
+  const ensureMaiaRef = useRef(ensureMaiaForNode)
+  const ensureStockfishRef = useRef(ensureStockfishForNode)
+  useEffect(() => {
+    ensureMaiaRef.current = ensureMaiaForNode
+  }, [ensureMaiaForNode])
+  useEffect(() => {
+    ensureStockfishRef.current = ensureStockfishForNode
+  }, [ensureStockfishForNode])
+
+  // The long-lived loop that drains the queue.
+  // Uses refs for everything so it never needs to be recreated.
   const runBackgroundLoop = useCallback(async () => {
     if (backgroundRunningRef.current) return
     backgroundRunningRef.current = true
 
+    console.log('[bg-analysis] loop started')
     try {
       while (backgroundQueueRef.current.length > 0) {
-        if (backgroundCancelledRef.current) break
+        if (backgroundCancelledRef.current) {
+          console.log('[bg-analysis] cancelled, stopping')
+          break
+        }
         const node = backgroundQueueRef.current[0]
+        console.log(
+          '[bg-analysis] processing node:',
+          node.fen.split(' ').slice(0, 2).join(' '),
+        )
 
-        await ensureMaiaForNode(node)
+        await ensureMaiaRef.current(node)
         if (backgroundCancelledRef.current) break
 
-        await ensureStockfishForNode(node)
+        console.log(
+          '[bg-analysis] maia done, starting stockfish for:',
+          node.fen.split(' ').slice(0, 2).join(' '),
+        )
+        await ensureStockfishRef.current(node)
 
         // Only remove from queue after both analyses complete (or if cancelled)
         backgroundQueueRef.current.shift()
+        console.log(
+          '[bg-analysis] node complete, remaining:',
+          backgroundQueueRef.current.length,
+        )
       }
+    } catch (error) {
+      console.error('[bg-analysis] error:', error)
     } finally {
       backgroundRunningRef.current = false
+      console.log('[bg-analysis] loop ended')
     }
-  }, [ensureMaiaForNode, ensureStockfishForNode])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Enqueue new drill nodes whenever the tree grows
   useEffect(() => {
@@ -963,6 +995,12 @@ export const useOpeningDrillController = (
     })
 
     if (newNodes.length > 0) {
+      console.log(
+        '[bg-analysis] enqueueing',
+        newNodes.length,
+        'nodes, loop running:',
+        backgroundRunningRef.current,
+      )
       backgroundQueueRef.current.push(...newNodes)
       runBackgroundLoop()
     }
@@ -974,17 +1012,31 @@ export const useOpeningDrillController = (
     treeController.currentNode,
   ])
 
-  // Cancel background analysis when drill session resets
+  // Cancel background analysis when a new drill starts (not on every move).
+  // currentDrillGame changes on every move, so we track the drill ID instead.
+  const backgroundDrillIdRef = useRef<string | null>(null)
   useEffect(() => {
-    backgroundCancelledRef.current = false
-    return () => {
+    const drillId = currentDrillGame?.id ?? null
+    if (drillId !== backgroundDrillIdRef.current) {
+      // New drill or drill cleared — cancel any running background work
       backgroundCancelledRef.current = true
       backgroundQueueRef.current = []
+      backgroundRunningRef.current = false
+
+      backgroundDrillIdRef.current = drillId
+      if (drillId) {
+        // Reset for the new drill
+        backgroundCancelledRef.current = false
+      }
     }
-  }, [currentDrillGame])
+  }, [currentDrillGame?.id])
 
   const ensureDrillAnalysis = useCallback(
     async (drillGame: OpeningDrillGame): Promise<boolean> => {
+      // Stop background analysis so it doesn't compete for stockfish
+      backgroundCancelledRef.current = true
+      backgroundQueueRef.current = []
+
       const mainLine = drillGame.tree.getMainLine()
       const startingNode = drillGame.openingEndNode || mainLine[0]
       const startIndex = startingNode

--- a/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
+++ b/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
@@ -926,23 +926,43 @@ export const useOpeningDrillController = (
   }, [ensureStockfishForNode])
 
   const runBgLoop = useCallback(async () => {
-    if (bgRunningRef.current) return
+    if (bgRunningRef.current) {
+      console.log('[bg] loop already running, skipping')
+      return
+    }
     bgRunningRef.current = true
+    console.log('[bg] loop STARTED, queue size:', bgQueueRef.current.length)
     try {
       while (bgQueueRef.current.length > 0) {
-        if (bgCancelledRef.current) break
+        if (bgCancelledRef.current) {
+          console.log('[bg] cancelled flag set, breaking')
+          break
+        }
         const node = bgQueueRef.current[0]
+        const fen = node.fen.split(' ').slice(0, 3).join(' ')
 
+        console.log('[bg] maia start:', fen)
         await ensureMaiaRef.current(node)
-        if (bgCancelledRef.current) break
+        const hasMaia =
+          node.analysis.maia &&
+          MAIA_MODELS.every((m) => node.analysis.maia?.[m])
+        console.log('[bg] maia done:', fen, 'hasMaia:', hasMaia)
+        if (bgCancelledRef.current) {
+          console.log('[bg] cancelled after maia, breaking')
+          break
+        }
 
+        console.log('[bg] stockfish start:', fen)
         await ensureStockfishRef.current(node)
+        const sfDepth = node.analysis.stockfish?.depth ?? 0
+        console.log('[bg] stockfish done:', fen, 'depth:', sfDepth)
         bgQueueRef.current.shift()
       }
     } catch (error) {
-      console.error('[bg-analysis] error:', error)
+      console.error('[bg] error:', error)
     } finally {
       bgRunningRef.current = false
+      console.log('[bg] loop ENDED, remaining:', bgQueueRef.current.length)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -990,6 +1010,18 @@ export const useOpeningDrillController = (
       return !hasMaia || !hasStockfish
     })
 
+    console.log(
+      '[bg] enqueue effect: drillNodes:',
+      drillNodes.length,
+      'newNodes:',
+      newNodes.length,
+      'queueSize:',
+      bgQueueRef.current.length,
+      'running:',
+      bgRunningRef.current,
+      'cancelled:',
+      bgCancelledRef.current,
+    )
     if (newNodes.length > 0) {
       bgQueueRef.current.push(...newNodes)
       const promise = runBgLoop()

--- a/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
+++ b/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
@@ -906,16 +906,13 @@ export const useOpeningDrillController = (
   // Background analysis: run Maia + Stockfish on drill positions as they are
   // played so post-drill analysis has less (or no) work to do.
   //
-  // There is a single Stockfish WASM instance, so we MUST NOT run background
-  // and post-drill Stockfish concurrently. When the drill ends we:
-  //   1. Set bgCancelledRef = true (loop exits after current position)
-  //   2. Call stockfish.stopEvaluation() to abort any in-progress eval
-  //   3. Await bgLoopPromiseRef to ensure the loop has fully exited
-  //   4. Only then start ensureDrillAnalysis
-  const bgQueueRef = useRef<GameNode[]>([])
-  const bgRunningRef = useRef(false)
+  // Uses a simple promise-chain pattern: each node's analysis is chained onto
+  // a single promise ref. No queue management, no running flags — just append
+  // work to the chain. Nodes are tracked by FEN in a Set to avoid duplicates.
+  const bgChainRef = useRef<Promise<void>>(Promise.resolve())
+  const bgAnalyzedFensRef = useRef<Set<string>>(new Set())
   const bgCancelledRef = useRef(false)
-  const bgLoopPromiseRef = useRef<Promise<void> | null>(null)
+  const bgDrillIdRef = useRef<string | null>(null)
   const ensureMaiaRef = useRef(ensureMaiaForNode)
   const ensureStockfishRef = useRef(ensureStockfishForNode)
   useEffect(() => {
@@ -925,69 +922,20 @@ export const useOpeningDrillController = (
     ensureStockfishRef.current = ensureStockfishForNode
   }, [ensureStockfishForNode])
 
-  const runBgLoop = useCallback(async () => {
-    if (bgRunningRef.current) {
-      console.log('[bg] loop already running, skipping')
-      return
-    }
-    bgRunningRef.current = true
-    console.log('[bg] loop STARTED, queue size:', bgQueueRef.current.length)
-    try {
-      while (bgQueueRef.current.length > 0) {
-        if (bgCancelledRef.current) {
-          console.log('[bg] cancelled flag set, breaking')
-          break
-        }
-        const node = bgQueueRef.current[0]
-        const fen = node.fen.split(' ').slice(0, 3).join(' ')
-
-        console.log('[bg] maia start:', fen)
-        await ensureMaiaRef.current(node)
-        const hasMaia =
-          node.analysis.maia &&
-          MAIA_MODELS.every((m) => node.analysis.maia?.[m])
-        console.log('[bg] maia done:', fen, 'hasMaia:', hasMaia)
-        if (bgCancelledRef.current) {
-          console.log('[bg] cancelled after maia, breaking')
-          break
-        }
-
-        console.log('[bg] stockfish start:', fen)
-        await ensureStockfishRef.current(node)
-        const sfDepth = node.analysis.stockfish?.depth ?? 0
-        console.log('[bg] stockfish done:', fen, 'depth:', sfDepth)
-        bgQueueRef.current.shift()
-      }
-    } catch (error) {
-      console.error('[bg] error:', error)
-    } finally {
-      bgRunningRef.current = false
-      console.log('[bg] loop ENDED, remaining:', bgQueueRef.current.length)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // Enqueue new drill positions for background analysis.
-  // Also handles drill-change detection (must be in the same effect to avoid
-  // the cancellation effect clearing the queue after the enqueue effect fills it).
-  const bgDrillIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (!currentDrillGame || isAnalyzingDrill) {
-      // No active drill or post-drill analysis is running — cancel background
-      if (bgDrillIdRef.current !== null) {
-        bgCancelledRef.current = true
-        bgQueueRef.current = []
-        bgDrillIdRef.current = null
-      }
       return
     }
 
-    // If drill changed, reset background state for the new drill
+    // If drill changed, reset for the new drill
     if (currentDrillGame.id !== bgDrillIdRef.current) {
       bgCancelledRef.current = true
-      bgQueueRef.current = []
+      // Let any in-flight work finish with the cancelled flag, then reset
+      bgChainRef.current = bgChainRef.current.then(() => {
+        bgCancelledRef.current = false
+      })
+      bgAnalyzedFensRef.current = new Set()
       bgDrillIdRef.current = currentDrillGame.id
-      bgCancelledRef.current = false
     }
 
     const mainLine = gameTree.getMainLine()
@@ -997,53 +945,27 @@ export const useOpeningDrillController = (
       : 0
     const drillNodes = mainLine.slice(startIndex)
 
-    const queuedFens = new Set(bgQueueRef.current.map((n) => n.fen))
+    for (const node of drillNodes) {
+      if (bgAnalyzedFensRef.current.has(node.fen)) continue
+      bgAnalyzedFensRef.current.add(node.fen)
 
-    const newNodes = drillNodes.filter((node) => {
-      if (queuedFens.has(node.fen)) return false
-      const hasMaia =
-        node.analysis.maia &&
-        MAIA_MODELS.every((model) => node.analysis.maia?.[model])
-      const hasStockfish =
-        node.analysis.stockfish &&
-        node.analysis.stockfish.depth >= DRILL_STOCKFISH_TARGET_DEPTH
-      return !hasMaia || !hasStockfish
-    })
-
-    console.log(
-      '[bg] enqueue effect: drillNodes:',
-      drillNodes.length,
-      'newNodes:',
-      newNodes.length,
-      'queueSize:',
-      bgQueueRef.current.length,
-      'running:',
-      bgRunningRef.current,
-      'cancelled:',
-      bgCancelledRef.current,
-    )
-    if (newNodes.length > 0) {
-      bgQueueRef.current.push(...newNodes)
-      const promise = runBgLoop()
-      if (promise) bgLoopPromiseRef.current = promise
+      // Chain this node's analysis onto the promise chain
+      bgChainRef.current = bgChainRef.current.then(async () => {
+        if (bgCancelledRef.current) return
+        console.log('[bg] analyzing:', node.fen.split(' ')[0].slice(-20))
+        await ensureMaiaRef.current(node)
+        if (bgCancelledRef.current) return
+        await ensureStockfishRef.current(node)
+        console.log('[bg] done, sf depth:', node.analysis.stockfish?.depth ?? 0)
+      })
     }
-  }, [
-    currentDrillGame,
-    gameTree,
-    isAnalyzingDrill,
-    runBgLoop,
-    treeController.currentNode,
-  ])
+  }, [currentDrillGame, gameTree, isAnalyzingDrill, treeController.currentNode])
 
-  // Helper: stop background loop and wait for it to fully exit
+  // Helper: stop background analysis and wait for it to fully settle
   const stopBackgroundAnalysis = useCallback(async () => {
     bgCancelledRef.current = true
-    bgQueueRef.current = []
     stockfish.stopEvaluation()
-    if (bgLoopPromiseRef.current) {
-      await bgLoopPromiseRef.current
-      bgLoopPromiseRef.current = null
-    }
+    await bgChainRef.current
   }, [stockfish])
 
   const ensureDrillAnalysis = useCallback(

--- a/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
+++ b/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
@@ -947,9 +947,28 @@ export const useOpeningDrillController = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Enqueue new drill positions for background analysis
+  // Enqueue new drill positions for background analysis.
+  // Also handles drill-change detection (must be in the same effect to avoid
+  // the cancellation effect clearing the queue after the enqueue effect fills it).
+  const bgDrillIdRef = useRef<string | null>(null)
   useEffect(() => {
-    if (!currentDrillGame || isAnalyzingDrill) return
+    if (!currentDrillGame || isAnalyzingDrill) {
+      // No active drill or post-drill analysis is running — cancel background
+      if (bgDrillIdRef.current !== null) {
+        bgCancelledRef.current = true
+        bgQueueRef.current = []
+        bgDrillIdRef.current = null
+      }
+      return
+    }
+
+    // If drill changed, reset background state for the new drill
+    if (currentDrillGame.id !== bgDrillIdRef.current) {
+      bgCancelledRef.current = true
+      bgQueueRef.current = []
+      bgDrillIdRef.current = currentDrillGame.id
+      bgCancelledRef.current = false
+    }
 
     const mainLine = gameTree.getMainLine()
     const openingEndNode = currentDrillGame.openingEndNode
@@ -983,20 +1002,6 @@ export const useOpeningDrillController = (
     runBgLoop,
     treeController.currentNode,
   ])
-
-  // Cancel background analysis when a new drill starts
-  const bgDrillIdRef = useRef<string | null>(null)
-  useEffect(() => {
-    const drillId = currentDrillGame?.id ?? null
-    if (drillId !== bgDrillIdRef.current) {
-      bgCancelledRef.current = true
-      bgQueueRef.current = []
-      bgDrillIdRef.current = drillId
-      if (drillId) {
-        bgCancelledRef.current = false
-      }
-    }
-  }, [currentDrillGame?.id])
 
   // Helper: stop background loop and wait for it to fully exit
   const stopBackgroundAnalysis = useCallback(async () => {

--- a/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
+++ b/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
@@ -903,19 +903,19 @@ export const useOpeningDrillController = (
     [currentMaiaModel, stockfish],
   )
 
-  // Background analysis: run Maia + Stockfish on positions as they are played
-  // so that post-drill analysis is already complete (or nearly so) when the
-  // drill ends.
+  // Background analysis: run Maia + Stockfish on drill positions as they are
+  // played so post-drill analysis has less (or no) work to do.
   //
-  // We use a ref-based queue so the async loop persists across re-renders.
-  // The useEffect only *enqueues* new nodes; the loop processes them
-  // independently of the React lifecycle to avoid being killed on every move.
-  const backgroundQueueRef = useRef<GameNode[]>([])
-  const backgroundRunningRef = useRef(false)
-  const backgroundCancelledRef = useRef(false)
-
-  // Refs to the latest versions of the analysis functions so the long-lived
-  // loop always calls the current closure without needing to restart.
+  // There is a single Stockfish WASM instance, so we MUST NOT run background
+  // and post-drill Stockfish concurrently. When the drill ends we:
+  //   1. Set bgCancelledRef = true (loop exits after current position)
+  //   2. Call stockfish.stopEvaluation() to abort any in-progress eval
+  //   3. Await bgLoopPromiseRef to ensure the loop has fully exited
+  //   4. Only then start ensureDrillAnalysis
+  const bgQueueRef = useRef<GameNode[]>([])
+  const bgRunningRef = useRef(false)
+  const bgCancelledRef = useRef(false)
+  const bgLoopPromiseRef = useRef<Promise<void> | null>(null)
   const ensureMaiaRef = useRef(ensureMaiaForNode)
   const ensureStockfishRef = useRef(ensureStockfishForNode)
   useEffect(() => {
@@ -925,51 +925,29 @@ export const useOpeningDrillController = (
     ensureStockfishRef.current = ensureStockfishForNode
   }, [ensureStockfishForNode])
 
-  // The long-lived loop that drains the queue.
-  // Uses refs for everything so it never needs to be recreated.
-  const runBackgroundLoop = useCallback(async () => {
-    if (backgroundRunningRef.current) return
-    backgroundRunningRef.current = true
-
-    console.log('[bg-analysis] loop started')
+  const runBgLoop = useCallback(async () => {
+    if (bgRunningRef.current) return
+    bgRunningRef.current = true
     try {
-      while (backgroundQueueRef.current.length > 0) {
-        if (backgroundCancelledRef.current) {
-          console.log('[bg-analysis] cancelled, stopping')
-          break
-        }
-        const node = backgroundQueueRef.current[0]
-        console.log(
-          '[bg-analysis] processing node:',
-          node.fen.split(' ').slice(0, 2).join(' '),
-        )
+      while (bgQueueRef.current.length > 0) {
+        if (bgCancelledRef.current) break
+        const node = bgQueueRef.current[0]
 
         await ensureMaiaRef.current(node)
-        if (backgroundCancelledRef.current) break
+        if (bgCancelledRef.current) break
 
-        console.log(
-          '[bg-analysis] maia done, starting stockfish for:',
-          node.fen.split(' ').slice(0, 2).join(' '),
-        )
         await ensureStockfishRef.current(node)
-
-        // Only remove from queue after both analyses complete (or if cancelled)
-        backgroundQueueRef.current.shift()
-        console.log(
-          '[bg-analysis] node complete, remaining:',
-          backgroundQueueRef.current.length,
-        )
+        bgQueueRef.current.shift()
       }
     } catch (error) {
       console.error('[bg-analysis] error:', error)
     } finally {
-      backgroundRunningRef.current = false
-      console.log('[bg-analysis] loop ended')
+      bgRunningRef.current = false
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Enqueue new drill nodes whenever the tree grows
+  // Enqueue new drill positions for background analysis
   useEffect(() => {
     if (!currentDrillGame || isAnalyzingDrill) return
 
@@ -980,8 +958,7 @@ export const useOpeningDrillController = (
       : 0
     const drillNodes = mainLine.slice(startIndex)
 
-    // Track FENs already in the queue to avoid duplicates
-    const queuedFens = new Set(backgroundQueueRef.current.map((n) => n.fen))
+    const queuedFens = new Set(bgQueueRef.current.map((n) => n.fen))
 
     const newNodes = drillNodes.filter((node) => {
       if (queuedFens.has(node.fen)) return false
@@ -995,47 +972,47 @@ export const useOpeningDrillController = (
     })
 
     if (newNodes.length > 0) {
-      console.log(
-        '[bg-analysis] enqueueing',
-        newNodes.length,
-        'nodes, loop running:',
-        backgroundRunningRef.current,
-      )
-      backgroundQueueRef.current.push(...newNodes)
-      runBackgroundLoop()
+      bgQueueRef.current.push(...newNodes)
+      const promise = runBgLoop()
+      if (promise) bgLoopPromiseRef.current = promise
     }
   }, [
     currentDrillGame,
     gameTree,
     isAnalyzingDrill,
-    runBackgroundLoop,
+    runBgLoop,
     treeController.currentNode,
   ])
 
-  // Cancel background analysis when a new drill starts (not on every move).
-  // currentDrillGame changes on every move, so we track the drill ID instead.
-  const backgroundDrillIdRef = useRef<string | null>(null)
+  // Cancel background analysis when a new drill starts
+  const bgDrillIdRef = useRef<string | null>(null)
   useEffect(() => {
     const drillId = currentDrillGame?.id ?? null
-    if (drillId !== backgroundDrillIdRef.current) {
-      // New drill or drill cleared — cancel any running background work
-      backgroundCancelledRef.current = true
-      backgroundQueueRef.current = []
-      backgroundRunningRef.current = false
-
-      backgroundDrillIdRef.current = drillId
+    if (drillId !== bgDrillIdRef.current) {
+      bgCancelledRef.current = true
+      bgQueueRef.current = []
+      bgDrillIdRef.current = drillId
       if (drillId) {
-        // Reset for the new drill
-        backgroundCancelledRef.current = false
+        bgCancelledRef.current = false
       }
     }
   }, [currentDrillGame?.id])
 
+  // Helper: stop background loop and wait for it to fully exit
+  const stopBackgroundAnalysis = useCallback(async () => {
+    bgCancelledRef.current = true
+    bgQueueRef.current = []
+    stockfish.stopEvaluation()
+    if (bgLoopPromiseRef.current) {
+      await bgLoopPromiseRef.current
+      bgLoopPromiseRef.current = null
+    }
+  }, [stockfish])
+
   const ensureDrillAnalysis = useCallback(
     async (drillGame: OpeningDrillGame): Promise<boolean> => {
-      // Stop background analysis so it doesn't compete for stockfish
-      backgroundCancelledRef.current = true
-      backgroundQueueRef.current = []
+      // Stop background loop and wait for it to fully exit before using stockfish
+      await stopBackgroundAnalysis()
 
       const mainLine = drillGame.tree.getMainLine()
       const startingNode = drillGame.openingEndNode || mainLine[0]
@@ -1111,7 +1088,12 @@ export const useOpeningDrillController = (
 
       return !wasCancelled
     },
-    [ensureMaiaForNode, ensureStockfishForNode, setDrillAnalysisProgress],
+    [
+      ensureMaiaForNode,
+      ensureStockfishForNode,
+      setDrillAnalysisProgress,
+      stopBackgroundAnalysis,
+    ],
   )
 
   const cancelDrillAnalysis = useCallback(() => {

--- a/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
+++ b/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
@@ -906,8 +906,38 @@ export const useOpeningDrillController = (
   // Background analysis: run Maia + Stockfish on positions as they are played
   // so that post-drill analysis is already complete (or nearly so) when the
   // drill ends.
-  const backgroundAnalysisQueueRef = useRef<Set<string>>(new Set())
+  //
+  // We use a ref-based queue so the async loop persists across re-renders.
+  // The useEffect only *enqueues* new nodes; the loop processes them
+  // independently of the React lifecycle to avoid being killed on every move.
+  const backgroundQueueRef = useRef<GameNode[]>([])
+  const backgroundRunningRef = useRef(false)
+  const backgroundCancelledRef = useRef(false)
 
+  // The long-lived loop that drains the queue
+  const runBackgroundLoop = useCallback(async () => {
+    if (backgroundRunningRef.current) return
+    backgroundRunningRef.current = true
+
+    try {
+      while (backgroundQueueRef.current.length > 0) {
+        if (backgroundCancelledRef.current) break
+        const node = backgroundQueueRef.current[0]
+
+        await ensureMaiaForNode(node)
+        if (backgroundCancelledRef.current) break
+
+        await ensureStockfishForNode(node)
+
+        // Only remove from queue after both analyses complete (or if cancelled)
+        backgroundQueueRef.current.shift()
+      }
+    } finally {
+      backgroundRunningRef.current = false
+    }
+  }, [ensureMaiaForNode, ensureStockfishForNode])
+
+  // Enqueue new drill nodes whenever the tree grows
   useEffect(() => {
     if (!currentDrillGame || isAnalyzingDrill) return
 
@@ -918,9 +948,11 @@ export const useOpeningDrillController = (
       : 0
     const drillNodes = mainLine.slice(startIndex)
 
-    // Find nodes that still need analysis and haven't been queued yet
-    const nodesNeedingWork = drillNodes.filter((node) => {
-      if (backgroundAnalysisQueueRef.current.has(node.fen)) return false
+    // Track FENs already in the queue to avoid duplicates
+    const queuedFens = new Set(backgroundQueueRef.current.map((n) => n.fen))
+
+    const newNodes = drillNodes.filter((node) => {
+      if (queuedFens.has(node.fen)) return false
       const hasMaia =
         node.analysis.maia &&
         MAIA_MODELS.every((model) => node.analysis.maia?.[model])
@@ -930,35 +962,26 @@ export const useOpeningDrillController = (
       return !hasMaia || !hasStockfish
     })
 
-    if (nodesNeedingWork.length === 0) return
-
-    let cancelled = false
-
-    const runBackgroundAnalysis = async () => {
-      for (const node of nodesNeedingWork) {
-        if (cancelled) break
-        backgroundAnalysisQueueRef.current.add(node.fen)
-        await ensureMaiaForNode(node)
-        if (cancelled) break
-        // Let Stockfish finish its current evaluation even if new moves come in
-        await ensureStockfishForNode(node)
-      }
-    }
-
-    runBackgroundAnalysis()
-
-    return () => {
-      cancelled = true
+    if (newNodes.length > 0) {
+      backgroundQueueRef.current.push(...newNodes)
+      runBackgroundLoop()
     }
   }, [
     currentDrillGame,
     gameTree,
     isAnalyzingDrill,
-    ensureMaiaForNode,
-    ensureStockfishForNode,
-    // Re-run when tree grows (new moves played)
+    runBackgroundLoop,
     treeController.currentNode,
   ])
+
+  // Cancel background analysis when drill session resets
+  useEffect(() => {
+    backgroundCancelledRef.current = false
+    return () => {
+      backgroundCancelledRef.current = true
+      backgroundQueueRef.current = []
+    }
+  }, [currentDrillGame])
 
   const ensureDrillAnalysis = useCallback(
     async (drillGame: OpeningDrillGame): Promise<boolean> => {

--- a/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
+++ b/src/hooks/useOpeningDrillController/useOpeningDrillController.ts
@@ -949,29 +949,45 @@ export const useOpeningDrillController = (
       if (bgAnalyzedFensRef.current.has(node.fen)) continue
       bgAnalyzedFensRef.current.add(node.fen)
 
-      // Chain this node's analysis onto the promise chain
+      // Chain this node's analysis onto the promise chain.
+      // Wrapped in try/catch so one failure doesn't break the whole chain.
       bgChainRef.current = bgChainRef.current.then(async () => {
-        if (bgCancelledRef.current) return
-        console.log('[bg] analyzing:', node.fen.split(' ')[0].slice(-20))
-        await ensureMaiaRef.current(node)
-        if (bgCancelledRef.current) return
-        await ensureStockfishRef.current(node)
-        console.log('[bg] done, sf depth:', node.analysis.stockfish?.depth ?? 0)
+        try {
+          if (bgCancelledRef.current) return
+          console.log('[bg] maia start:', node.san || node.move || '?')
+          await ensureMaiaRef.current(node)
+          const hasMaia = !!(
+            node.analysis.maia &&
+            MAIA_MODELS.every((m) => node.analysis.maia?.[m])
+          )
+          console.log('[bg] maia done:', hasMaia, '| sf start')
+          if (bgCancelledRef.current) return
+          await ensureStockfishRef.current(node)
+          console.log(
+            '[bg] sf done, depth:',
+            node.analysis.stockfish?.depth ?? 0,
+          )
+        } catch (error) {
+          console.error('[bg] error analyzing node:', error)
+        }
       })
     }
   }, [currentDrillGame, gameTree, isAnalyzingDrill, treeController.currentNode])
 
-  // Helper: stop background analysis and wait for it to fully settle
-  const stopBackgroundAnalysis = useCallback(async () => {
+  // Stop background analysis. Signals cancellation and stops stockfish so
+  // ensureDrillAnalysis can use stockfish immediately. The chain's remaining
+  // .then() callbacks will see the cancelled flag and return quickly.
+  // Does NOT await the chain — avoids hanging if a step is stuck.
+  const stopBackgroundAnalysis = useCallback(() => {
     bgCancelledRef.current = true
     stockfish.stopEvaluation()
-    await bgChainRef.current
   }, [stockfish])
 
   const ensureDrillAnalysis = useCallback(
     async (drillGame: OpeningDrillGame): Promise<boolean> => {
-      // Stop background loop and wait for it to fully exit before using stockfish
-      await stopBackgroundAnalysis()
+      // Signal background to stop and give the generator a tick to clean up
+      stopBackgroundAnalysis()
+      await delay(50)
 
       const mainLine = drillGame.tree.getMainLine()
       const startingNode = drillGame.openingEndNode || mainLine[0]

--- a/src/pages/openings/index.tsx
+++ b/src/pages/openings/index.tsx
@@ -180,6 +180,7 @@ const OpeningsPage: NextPage = () => {
     },
     controller.currentDrill?.playerColor || 'white',
     false, // Disable auto-saving on openings page
+    controller.analysisEnabled || controller.continueAnalyzingMode, // Disable engine analysis during drill play
   )
 
   // Sync analysis controller with current node — only when analysis is active

--- a/src/pages/openings/index.tsx
+++ b/src/pages/openings/index.tsx
@@ -182,12 +182,23 @@ const OpeningsPage: NextPage = () => {
     false, // Disable auto-saving on openings page
   )
 
-  // Sync analysis controller with current node
+  // Sync analysis controller with current node — only when analysis is active
+  // (post-drill continue-analyzing mode). During drill play, the analysis
+  // controller's auto-stockfish would conflict with background analysis.
   useEffect(() => {
-    if (controller.currentNode && analysisController.setCurrentNode) {
+    if (
+      controller.currentNode &&
+      analysisController.setCurrentNode &&
+      (controller.analysisEnabled || controller.continueAnalyzingMode)
+    ) {
       analysisController.setCurrentNode(controller.currentNode)
     }
-  }, [controller.currentNode, analysisController.setCurrentNode])
+  }, [
+    controller.currentNode,
+    controller.analysisEnabled,
+    controller.continueAnalyzingMode,
+    analysisController.setCurrentNode,
+  ])
 
   // Create game object for MovesContainer
   const gameForContainer = useMemo(() => {


### PR DESCRIPTION
## Summary

- **Background analysis during drills**: While the player is actively playing a drill, Maia and Stockfish analysis runs in the background on all positions in the drill's main line. This means post-drill analysis is faster or instant since most positions are already analyzed.
- **Promise-chain pattern**: Background analysis uses a sequential promise chain (`bgChainRef`) to avoid clobbering the single Stockfish WASM instance. Each node is analyzed one at a time (Maia first, then Stockfish).
- **Disable engine analysis during drill play**: Added an `enabled` flag to `useEngineAnalysis` so the analysis controller doesn't auto-fire Stockfish on every board position change during drills, which would steal the engine from background analysis.

## Key changes

- `useOpeningDrillController.ts` — Background analysis lifecycle (enqueue, cancel on drill change, stop on drill end)
- `useEngineAnalysis.ts` — Added `enabled` parameter to gate Maia/Stockfish effects
- `useAnalysisController.ts` — Passes `enableEngineAnalysis` flag through
- `openings/index.tsx` — Disables engine analysis during drill play, only syncs nodes when analysis is active

## Test plan

- [ ] Start a drill and verify console logs show background Maia + Stockfish analysis progressing through positions
- [ ] Complete a drill and verify the post-drill analysis modal loads faster (positions already analyzed show immediately)
- [ ] Verify post-drill analysis still works correctly for any positions not yet reached by background analysis
- [ ] Verify switching drills mid-play cancels background analysis and starts fresh
- [ ] Verify normal (non-drill) analysis page still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)