### PR TITLE
Add candidates challenge hub

### DIFF
--- a/src/components/Analysis/BroadcastAnalysis.tsx
+++ b/src/components/Analysis/BroadcastAnalysis.tsx
@@ -1227,6 +1227,7 @@ export const BroadcastAnalysis: React.FC<Props> = ({
                 <MovesByRating
                   moves={analysisController.movesByRating}
                   colorSanMapping={analysisController.colorSanMapping}
+                  positionKey={analysisController.currentNode?.fen}
                 />
               </div>
             </div>

--- a/src/pages/broadcast/[broadcastId]/[roundId].tsx
+++ b/src/pages/broadcast/[broadcastId]/[roundId].tsx
@@ -115,12 +115,21 @@ const BroadcastAnalysisPage: NextPage = () => {
     undefined,
     false,
   )
+  const defaultModelAppliedForGameId = useRef<string | null>(null)
 
   useEffect(() => {
-    if (analysisController.currentMaiaModel !== 'maia_kdd_2600') {
-      analysisController.setCurrentMaiaModel('maia_kdd_2600')
-    }
+    const gameId = broadcastController.currentGame?.id
+    if (!gameId) return
+
+    if (defaultModelAppliedForGameId.current === gameId) return
+
+    defaultModelAppliedForGameId.current = gameId
+
+    if (analysisController.currentMaiaModel === 'maia_kdd_2600') return
+
+    analysisController.setCurrentMaiaModel('maia_kdd_2600')
   }, [
+    broadcastController.currentGame?.id,
     analysisController.currentMaiaModel,
     analysisController.setCurrentMaiaModel,
   ])

--- a/src/pages/candidates.tsx
+++ b/src/pages/candidates.tsx
@@ -16,6 +16,7 @@ import {
 import { GameTree } from 'src/types'
 
 const CANDIDATES_COMPLETED_STORAGE_KEY = 'maia-candidates-completed'
+const CANDIDATES_BROADCAST_HREF = '/broadcast/BLA70Vds/uLCZwqAK'
 
 const readCompletedChallenges = (): string[] => {
   if (typeof window === 'undefined') return []
@@ -241,6 +242,15 @@ export default function CandidatesPage() {
             <p className="mt-2 text-sm uppercase tracking-[0.2em] text-white/45">
               Round 1
             </p>
+            <Link
+              href={CANDIDATES_BROADCAST_HREF}
+              className="mt-4 inline-flex items-center gap-2 rounded-full border border-sky-300/25 bg-sky-500/10 px-4 py-2 text-sm font-medium text-sky-100 transition hover:border-sky-200/40 hover:bg-sky-500/15"
+            >
+              <span className="material-symbols-outlined !text-[18px]">
+                live_tv
+              </span>
+              Watch Candidates Broadcast
+            </Link>
           </header>
           {positions.map((position) => (
             <PositionPill


### PR DESCRIPTION
## Summary
- add a dedicated Candidates page with challenge cards, local completion tracking, and clickable board previews
- wire Candidates challenge flows into Maia play setup, return handling, and custom drill/analysis links
- surface Candidates as a featured nav destination in the shared header and link to the live Candidates broadcast

## Testing
- ./node_modules/.bin/tsc --noEmit --pretty false
- npm run build