### PR TITLE
Add round 4 candidates challenges

### DIFF
--- a/src/constants/candidates.ts
+++ b/src/constants/candidates.ts
@@ -74,6 +74,51 @@ export const CANDIDATES_EXTRA_IDEAS: CandidateIdea[] = [
 // Drop live tournament moments here as PGN or FEN during the event.
 export const CANDIDATES_FEATURED_POSITIONS: CandidatePosition[] = [
   {
+    id: 'rd4-sindarov-breakthrough',
+    title: "Rd4 Challenge 1: Sindarov's Breakthrough",
+    subtitle:
+      "Can you break through against Black's damaged structure? (Sindarov—Caruana)",
+    summary:
+      "White to move in a sharp position against Caruana's damaged structure. Break through and win.",
+    tag: 'Featured',
+    accent: 'red',
+    fen: '3q4/3r1pkp/5b2/2Rp1p2/Pp4r1/4B1P1/1P2QP1P/3R2K1 w - - 0 28',
+    playerColor: 'white',
+    maiaVersion: 'maia_kdd_1900',
+    targetMoveNumber: 8,
+  },
+  {
+    id: 'rd4-convert-like-zhu',
+    title: 'Rd4 Challenge 2: Convert Like Zhu',
+    subtitle:
+      'Black is two pawns up. Deal with the light square pressure and convert the win. (Deshmukh—Zhu)',
+    summary:
+      'Black is materially ahead but must handle light-square pressure to finish the conversion.',
+    tag: 'Featured',
+    accent: 'amber',
+    fen: 'r4r2/1p3qpk/2ppb2p/p2n1p2/P1Bb3P/1Q4P1/1P1BRPN1/R5K1 b - - 1 23',
+    playerColor: 'black',
+    maiaVersion: 'maia_kdd_1900',
+    targetMoveNumber: 8,
+  },
+  {
+    id: 'rd4-giri-wandering-king',
+    title: "Rd4 Challenge 3: Giri's Wandering King",
+    subtitle:
+      'Black has long-term advantages, but can you consolidate and win? (Esipenko—Giri)',
+    summary:
+      "Giri's king is active and Black has long-term trumps. Consolidate the edge and convert.",
+    tag: 'Featured',
+    accent: 'blue',
+    fen: '1kr4r/1p2bp1p/Q1b1p3/2pq3N/4N3/5P2/PR4PP/1R4K1 b - - 0 23',
+    playerColor: 'black',
+    maiaVersion: 'maia_kdd_1900',
+    targetMoveNumber: 8,
+  },
+]
+
+export const CANDIDATES_ROUND_THREE_POSITIONS: CandidatePosition[] = [
+  {
     id: 'rd3-convert-fabi-win',
     title: "Rd3 Challenge 1: Convert Fabi's Win",
     subtitle:

--- a/src/pages/candidates.tsx
+++ b/src/pages/candidates.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import {
   CANDIDATES_FEATURED_POSITIONS,
+  CANDIDATES_ROUND_THREE_POSITIONS,
   CANDIDATES_ROUND_TWO_POSITIONS,
   CANDIDATES_WARMUP_POSITIONS,
   CandidatePosition,
@@ -256,7 +257,7 @@ export default function CandidatesPage() {
               FIDE Candidates Tournament 2026
             </h1>
             <p className="mt-2 text-sm uppercase tracking-[0.2em] text-white/45">
-              Round 3
+              Round 4
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <Link
@@ -281,13 +282,24 @@ export default function CandidatesPage() {
           </header>
           {CANDIDATES_FEATURED_POSITIONS.length > 0 ? (
             <>
-              <ChallengeSectionTitle title="Round 3 Challenges" />
+              <ChallengeSectionTitle title="Round 4 Challenges" />
               {CANDIDATES_FEATURED_POSITIONS.map((position) => (
                 <PositionPill
                   key={position.id}
                   position={position}
                   completed={completedChallengeIds.includes(position.id)}
-                  compactTitle
+                />
+              ))}
+            </>
+          ) : null}
+          {CANDIDATES_ROUND_THREE_POSITIONS.length > 0 ? (
+            <>
+              <ChallengeSectionTitle title="Round 3 Challenges" />
+              {CANDIDATES_ROUND_THREE_POSITIONS.map((position) => (
+                <PositionPill
+                  key={position.id}
+                  position={position}
+                  completed={completedChallengeIds.includes(position.id)}
                 />
               ))}
             </>


### PR DESCRIPTION
## Summary
- add three Round 4 Candidates challenges and promote them to the top of the Candidates page
- keep earlier rounds below as separate Round 3, Round 2, and Round 1 sections
- remove the compact title treatment from the current round so longer Round 4 titles wrap cleanly

## Testing
- not run (UI/data update only)