### PR TITLE
Add round 9 candidates challenges

### DIFF
--- a/src/constants/candidates.ts
+++ b/src/constants/candidates.ts
@@ -74,6 +74,51 @@ export const CANDIDATES_EXTRA_IDEAS: CandidateIdea[] = [
 // Drop live tournament moments here as PGN or FEN during the event.
 export const CANDIDATES_FEATURED_POSITIONS: CandidatePosition[] = [
   {
+    id: 'rd9-attack-bluebaum-king',
+    title: "Rd9 Challenge 1: Attack Bluebaum's King",
+    subtitle:
+      'Sindarov made a rare mistake, missing 24. ...Qb7! Can you win from this position? (Bluebaum—Sindarov)',
+    summary:
+      "Black has attacking chances after Sindarov's mistake. Keep the initiative and finish the job.",
+    tag: 'Featured',
+    accent: 'red',
+    fen: 'rr4k1/1qp2ppp/2b1p3/6P1/P2QPP2/8/P1B4P/2KRR3 b - - 2 25',
+    playerColor: 'black',
+    maiaVersion: 'maia_kdd_1900',
+    targetMoveNumber: 8,
+  },
+  {
+    id: 'rd9-grind-like-giri',
+    title: 'Rd9 Challenge 2: Grind like Giri',
+    subtitle:
+      "Giri strategically outplayed Fabi and eventually won, ending the American's hopes. Can you convert this position? (Caruana—Giri)",
+    summary:
+      'Black has the better structure and king activity. Grind the endgame like Giri and convert.',
+    tag: 'Featured',
+    accent: 'amber',
+    fen: '4b3/2p3pk/1q1p1p1p/3Pp3/1pP1P3/1P1QP2P/r1N3PK/2R5 b - - 3 35',
+    playerColor: 'black',
+    maiaVersion: 'maia_kdd_1800',
+    targetMoveNumber: 8,
+  },
+  {
+    id: 'rd9-walk-pragg-tightrope',
+    title: "Rd9 Challenge 3: Walk Pragg's Tightrope",
+    subtitle:
+      "Pragg couldn't quite convert, missing 42.b4! Can you walk the tightrope after this move? (Praggnanandhaa—Wei)",
+    summary:
+      'White is balancing attack and defense in a sharp position. Stay precise and find the win.',
+    tag: 'Featured',
+    accent: 'blue',
+    fen: '5r2/p1Q3pk/b2Np2p/1p6/1P3P2/7P/1P1q2PK/5R2 w - - 1 43',
+    playerColor: 'white',
+    maiaVersion: 'maia_kdd_1900',
+    targetMoveNumber: 8,
+  },
+]
+
+export const CANDIDATES_ROUND_EIGHT_POSITIONS: CandidatePosition[] = [
+  {
     id: 'rd8-hikaru-technique',
     title: "Rd8 Challenge 1: Hikaru's Technique",
     subtitle:

--- a/src/pages/candidates.tsx
+++ b/src/pages/candidates.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import {
   CANDIDATES_FEATURED_POSITIONS,
+  CANDIDATES_ROUND_EIGHT_POSITIONS,
   CANDIDATES_ROUND_FOUR_POSITIONS,
   CANDIDATES_ROUND_THREE_POSITIONS,
   CANDIDATES_ROUND_TWO_POSITIONS,
@@ -210,6 +211,9 @@ export default function CandidatesPage() {
   const compactFeaturedTitles = shouldCompactTitles(
     CANDIDATES_FEATURED_POSITIONS,
   )
+  const compactRoundEightTitles = shouldCompactTitles(
+    CANDIDATES_ROUND_EIGHT_POSITIONS,
+  )
   const compactRoundFourTitles = shouldCompactTitles(
     CANDIDATES_ROUND_FOUR_POSITIONS,
   )
@@ -274,7 +278,7 @@ export default function CandidatesPage() {
               FIDE Candidates Tournament 2026
             </h1>
             <p className="mt-2 text-sm uppercase tracking-[0.2em] text-white/45">
-              Round 8
+              Round 9
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <Link
@@ -299,13 +303,26 @@ export default function CandidatesPage() {
           </header>
           {CANDIDATES_FEATURED_POSITIONS.length > 0 ? (
             <>
-              <ChallengeSectionTitle title="Round 8 Challenges" />
+              <ChallengeSectionTitle title="Round 9 Challenges" />
               {CANDIDATES_FEATURED_POSITIONS.map((position) => (
                 <PositionPill
                   key={position.id}
                   position={position}
                   completed={completedChallengeIds.includes(position.id)}
                   compactTitle={compactFeaturedTitles}
+                />
+              ))}
+            </>
+          ) : null}
+          {CANDIDATES_ROUND_EIGHT_POSITIONS.length > 0 ? (
+            <>
+              <ChallengeSectionTitle title="Round 8 Challenges" />
+              {CANDIDATES_ROUND_EIGHT_POSITIONS.map((position) => (
+                <PositionPill
+                  key={position.id}
+                  position={position}
+                  completed={completedChallengeIds.includes(position.id)}
+                  compactTitle={compactRoundEightTitles}
                 />
               ))}
             </>


### PR DESCRIPTION
## Summary
- add the Round 9 Candidates challenge set to the top of the Candidates page
- move the current Round 8 set into its own section below Round 9
- keep the earlier rounds and existing card layout intact

## Testing
- npx prettier --write src/constants/candidates.ts src/pages/candidates.tsx
- npx tsc --noEmit --pretty false

## Note
- this branch currently stacks on the unmerged Round 8 Candidates change