### PR TITLE
Add round 10 candidates challenges

### DIFF
--- a/src/constants/candidates.ts
+++ b/src/constants/candidates.ts
@@ -74,6 +74,51 @@ export const CANDIDATES_EXTRA_IDEAS: CandidateIdea[] = [
 // Drop live tournament moments here as PGN or FEN during the event.
 export const CANDIDATES_FEATURED_POSITIONS: CandidatePosition[] = [
   {
+    id: 'rd10-death-stare-follow-up',
+    title: 'Rd10 Challenge 1: Death Stare Follow-Up',
+    subtitle:
+      'Pragg blundered and Sindarov gave him the death stare before finding the best continuation. Can you cash this in for a big win? (Sindarov—Praggnanandhaa)',
+    summary:
+      'White has a crushing attack after Pragg blundered. Find the clean follow-up and cash in.',
+    tag: 'Featured',
+    accent: 'red',
+    fen: 'r5k1/pppb1R2/4q2r/4P3/4Q3/2P1P1Pp/P6P/5RK1 w - - 5 24',
+    playerColor: 'white',
+    maiaVersion: 'maia_kdd_1900',
+    targetMoveNumber: 8,
+  },
+  {
+    id: 'rd10-push-em',
+    title: "Rd10 Challenge 2: Push 'Em",
+    subtitle:
+      'White has the upper hand with pawns that can march down the board. (Assaubayeva—Zhu)',
+    summary:
+      'White has connected passers and active pieces. Push the pawns and convert.',
+    tag: 'Featured',
+    accent: 'amber',
+    fen: '4q1k1/5pb1/2p3p1/P2r3p/1PRp3P/3N1QP1/3R1PK1/r7 w - - 3 38',
+    playerColor: 'white',
+    maiaVersion: 'maia_kdd_1800',
+    targetMoveNumber: 8,
+  },
+  {
+    id: 'rd10-navigate-strategic-complexity',
+    title: 'Rd10 Challenge 3: Navigate Strategic Complexity',
+    subtitle:
+      'Giri had an interesting position against Nakamura but it fizzled out in the end. Can you do better? (Giri—Nakamura)',
+    summary:
+      'White has a rich strategic middlegame. Navigate the complications and improve on the game result.',
+    tag: 'Featured',
+    accent: 'blue',
+    fen: '3rr1k1/p2b1pp1/1ppqnn1p/3p4/3P4/1QN1P1NP/PP3PP1/1B1RR1K1 w - - 8 17',
+    playerColor: 'white',
+    maiaVersion: 'maia_kdd_1900',
+    targetMoveNumber: 8,
+  },
+]
+
+export const CANDIDATES_ROUND_NINE_POSITIONS: CandidatePosition[] = [
+  {
     id: 'rd9-attack-bluebaum-king',
     title: "Rd9 Challenge 1: Attack Bluebaum's King",
     subtitle:

--- a/src/pages/candidates.tsx
+++ b/src/pages/candidates.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import {
   CANDIDATES_FEATURED_POSITIONS,
+  CANDIDATES_ROUND_NINE_POSITIONS,
   CANDIDATES_ROUND_EIGHT_POSITIONS,
   CANDIDATES_ROUND_FOUR_POSITIONS,
   CANDIDATES_ROUND_THREE_POSITIONS,
@@ -186,10 +187,10 @@ const PositionPill: React.FC<{
         <div className="mt-auto flex justify-center">
           <Link
             href={playHref}
-            className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm text-primary transition ${
+            className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-primary shadow-[0_8px_24px_rgba(0,0,0,0.2)] transition ${
               completed
-                ? 'border border-emerald-300/30 bg-emerald-500/10 hover:border-emerald-200/45 hover:bg-emerald-500/15'
-                : 'border border-rose-300/25 bg-rose-500/10 hover:border-rose-200/40 hover:bg-rose-500/15'
+                ? 'bg-emerald-400/18 hover:bg-emerald-400/24 border border-emerald-200/55 hover:border-emerald-100/70'
+                : 'bg-rose-400/18 hover:bg-rose-400/24 border border-rose-200/50 hover:border-rose-100/65'
             }`}
           >
             <span className="material-symbols-outlined !text-[18px]">
@@ -210,6 +211,9 @@ export default function CandidatesPage() {
   )
   const compactFeaturedTitles = shouldCompactTitles(
     CANDIDATES_FEATURED_POSITIONS,
+  )
+  const compactRoundNineTitles = shouldCompactTitles(
+    CANDIDATES_ROUND_NINE_POSITIONS,
   )
   const compactRoundEightTitles = shouldCompactTitles(
     CANDIDATES_ROUND_EIGHT_POSITIONS,
@@ -278,7 +282,7 @@ export default function CandidatesPage() {
               FIDE Candidates Tournament 2026
             </h1>
             <p className="mt-2 text-sm uppercase tracking-[0.2em] text-white/45">
-              Round 9
+              Round 10
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <Link
@@ -303,13 +307,26 @@ export default function CandidatesPage() {
           </header>
           {CANDIDATES_FEATURED_POSITIONS.length > 0 ? (
             <>
-              <ChallengeSectionTitle title="Round 9 Challenges" />
+              <ChallengeSectionTitle title="Round 10 Challenges" />
               {CANDIDATES_FEATURED_POSITIONS.map((position) => (
                 <PositionPill
                   key={position.id}
                   position={position}
                   completed={completedChallengeIds.includes(position.id)}
                   compactTitle={compactFeaturedTitles}
+                />
+              ))}
+            </>
+          ) : null}
+          {CANDIDATES_ROUND_NINE_POSITIONS.length > 0 ? (
+            <>
+              <ChallengeSectionTitle title="Round 9 Challenges" />
+              {CANDIDATES_ROUND_NINE_POSITIONS.map((position) => (
+                <PositionPill
+                  key={position.id}
+                  position={position}
+                  completed={completedChallengeIds.includes(position.id)}
+                  compactTitle={compactRoundNineTitles}
                 />
               ))}
             </>


### PR DESCRIPTION
## Summary
- add the Round 10 Candidates challenge set to the top of the Candidates page
- move the current Round 9 set into its own section below Round 10
- brighten the challenge buttons so the start action stands out more clearly

## Testing
- npx prettier --write src/constants/candidates.ts src/pages/candidates.tsx
- npx tsc --noEmit --pretty false

## Note
- this branch currently stacks on the unmerged Round 9 Candidates change