### PR TITLE
fix: prevent play board hitbox shift on load

### DIFF
--- a/src/components/Common/Loading.tsx
+++ b/src/components/Common/Loading.tsx
@@ -110,8 +110,8 @@ export const Loading: React.FC<LoadingProps> = ({
       ) : !isLoading ? (
         <motion.div
           key="content"
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
           transition={{ duration: 0.4, ease: 'easeOut' }}
         >
           {children}


### PR DESCRIPTION
# Fix play board hitbox shift after loading

## Summary

This removes the vertical slide animation from the shared `Loading` content wrapper.

On the play page, Chessground can initialize while the loaded content is still animated from `y: 10` to `y: 0`. Because Chessground memoizes the board bounds used for mouse-to-square mapping, that temporary vertical offset can leave the click hitbox slightly out of sync with the visible board.

The content still fades in, but no longer moves vertically during mount.

## Changes

- Removed the `y` translation from the `Loading` content transition.
- Kept the opacity fade-in animation.
- No changes to `GameBoard` or Chessground configuration.
- No resize workaround.

## Test plan

- Open the play page as White.
- On the initial position, click the `c2` pawn and then click near the top of `c3`.
- Confirm the pawn moves to `c3`, not `c4`.
- Repeat after a hard refresh.
- Confirm the loading/content transition still fades in normally.
